### PR TITLE
Fix: Ensure text color is light in dark mode for Firefox

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,9 @@
 }
 
 [data-theme="dark"] {
+  * {
+    color: inherit;
+  }
   --bg-color: #212529;
   --text-color: #ffffff;
   --cell-bg: #343a40;


### PR DESCRIPTION
Previously, text could remain dark in Firefox when dark mode was active due to CSS specificity or inheritance issues, potentially conflicting with Bootstrap styles.

This change addresses the issue by:
1. Confirming that `[data-theme="dark"] body` uses `color: var(--text-color) !important;`.
2. Adding a general rule `[data-theme="dark"] * { color: inherit; }`. This forces all elements within the dark theme to inherit the `color` property from their parent, ultimately from `body`, unless a more specific rule explicitly sets their color. This helps ensure consistent text color according to the theme.